### PR TITLE
Non-date non-equality and immutable PAST and FUTURE

### DIFF
--- a/approx_dates/models.py
+++ b/approx_dates/models.py
@@ -3,8 +3,16 @@ from __future__ import unicode_literals
 import calendar
 from datetime import date
 import re
-
+from types import NoneType
 import six
+
+class classproperty(object):
+
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, owner_self, owner_cls):
+        return self.fget(owner_cls)
 
 
 ISO8601_DATE_REGEX_YYYY_MM_DD = \
@@ -25,7 +33,15 @@ class ApproxDate(object):
         self.earliest_date = earliest_date
         self.latest_date = latest_date
         self.source_string = source_string
+    
+    @classproperty
+    def FUTURE(cls):
+        return cls(_max_date, _max_date)
 
+    @classproperty
+    def PAST(cls):
+        return cls(_min_date, _min_date)
+    
     @classmethod
     def from_iso8601(self, iso8601_date_string):
         full_match = ISO8601_DATE_REGEX_YYYY_MM_DD.search(iso8601_date_string)
@@ -74,8 +90,11 @@ class ApproxDate(object):
         if isinstance(other, date):
             return self.earliest_date == self.latest_date and \
                self.earliest_date == other
-        return self.earliest_date == other.earliest_date and \
-            self.latest_date == other.latest_date
+        if hasattr(other,"earliest_date") and hasattr(other,"latest_date"):
+            return self.earliest_date == other.earliest_date and \
+                self.latest_date == other.latest_date
+        else:
+            return False
 
     def __ne__(self, other):
         return not (self == other)
@@ -103,7 +122,3 @@ class ApproxDate(object):
         except AttributeError:
             later_bound = end_date
         return earlier_bound <= d <= later_bound
-
-
-ApproxDate.FUTURE = ApproxDate(_max_date, _max_date)
-ApproxDate.PAST = ApproxDate(_min_date, _min_date)

--- a/approx_dates/models.py
+++ b/approx_dates/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import calendar
 from datetime import date
 import re
-from types import NoneType
 import six
 
 class classproperty(object):

--- a/approx_dates/tests/test_creation.py
+++ b/approx_dates/tests/test_creation.py
@@ -5,9 +5,6 @@ from approx_dates.models import ApproxDate
 from six import text_type
 import pytest
 
-print ApproxDate.PAST
-
-
 class TestCreation(TestCase):
 
     def test_create_from_full_iso_8601(self):

--- a/approx_dates/tests/test_creation.py
+++ b/approx_dates/tests/test_creation.py
@@ -5,6 +5,8 @@ from approx_dates.models import ApproxDate
 from six import text_type
 import pytest
 
+print ApproxDate.PAST
+
 
 class TestCreation(TestCase):
 
@@ -60,3 +62,14 @@ class TestCreation(TestCase):
         assert d.earliest_date == date(1, 1, 1)
         assert d.latest_date == date(1, 1, 1)
         assert text_type(d) == 'past'
+        
+    def test_future_past_immutable(self):
+        p = ApproxDate.PAST
+        p.earliest_date = date(1,1,5)
+        assert p != ApproxDate.PAST
+        p = ApproxDate.FUTURE
+        p.earliest_date = date(8888, 12, 31)
+        assert p != ApproxDate.PAST        
+        
+        
+        

--- a/approx_dates/tests/test_equality.py
+++ b/approx_dates/tests/test_equality.py
@@ -59,3 +59,11 @@ class TestApproxDateEquality(TestCase):
         approx_date = ApproxDate.from_iso8601('1999')
         datetime_date = date(1964, 6, 26)
         assert not (approx_date == datetime_date)
+        
+    # Comparisons to other objects should be false, not fail 
+    def test_past_is_not_non_date(self):
+        approx_date = ApproxDate.PAST
+        assert not (approx_date == None)
+        assert not (approx_date == "past")
+        assert not (approx_date == 15)
+


### PR DESCRIPTION
Allows equality comparisons to be false against non-date types (None, "hello" etc).

Makes ApproxDate.PAST and .FUTURE return a new instance of ApproxDate each time called - prevents modifying one .FUTURE changing all current references.

Added tests to reflect these.