### PR TITLE
Amend ApproxDate to return an isostring of its contents.

### DIFF
--- a/approx_dates/tests/test_creation.py
+++ b/approx_dates/tests/test_creation.py
@@ -47,7 +47,7 @@ class TestCreation(TestCase):
 
     def test_abritrary_date_range(self):
         d = ApproxDate(date(1926, 1, 3), date(2016, 3, 8))
-        assert text_type(d) == '1926-01-03 to 2016-03-08'
+        assert text_type(d) == '1926-01-03/2016-03-08'
 
     def test_future(self):
         d = ApproxDate.FUTURE

--- a/approx_dates/tests/test_range.py
+++ b/approx_dates/tests/test_range.py
@@ -47,3 +47,13 @@ class TestRange(TestCase):
         d1 = date(2000, 1, 1)
         d2 = date(2005, 12, 31)
         assert not ApproxDate.possibly_between(d1, date(1980, 1, 1), d2)
+
+    def test_iso_conversions(self):
+        a = ApproxDate.from_iso8601("2015")
+        assert a.to_iso8601() == "2015"
+        a = ApproxDate.from_iso8601("2015-06")
+        assert a.to_iso8601() == "2015-06"
+        a = ApproxDate.from_iso8601("2015-06-23")
+        assert a.to_iso8601() == "2015-06-23"
+        a = ApproxDate.from_iso8601("2015-06-23/2015-07-12")
+        assert a.to_iso8601() == "2015-06-23/2015-07-12"


### PR DESCRIPTION
to_iso8601 - will try and render the simplest version of a date range.
from_iso8601 amended to accept two isostrings seperated by ' to '.
Tests added to check different kinds of dates are converted into ApproxDate
and back successfully.