### PR TITLE
Make .PAST and .FUTURE return new copies of instance.

### DIFF
--- a/approx_dates/models.py
+++ b/approx_dates/models.py
@@ -6,6 +6,20 @@ import re
 
 import six
 
+class classproperty(object):
+    """
+    This decorator acts as @property (returning a new result
+    from the method each time the property is requested) but
+    for what would otherwise be a @classmethod.
+    source: http://stackoverflow.com/a/13624858/223092
+    """
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, owner_self, owner_cls):
+        return self.fget(owner_cls)
+
+
 
 ISO8601_DATE_REGEX_YYYY_MM_DD = \
     re.compile(r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$')
@@ -20,6 +34,14 @@ _min_date = date(1, 1, 1)
 
 @six.python_2_unicode_compatible
 class ApproxDate(object):
+
+    @classproperty
+    def FUTURE(cls):
+        return cls(_max_date, _max_date)
+
+    @classproperty
+    def PAST(cls):
+        return cls(_min_date, _min_date)
 
     def __init__(self, earliest_date, latest_date, source_string=None):
         self.earliest_date = earliest_date
@@ -107,6 +129,3 @@ class ApproxDate(object):
             later_bound = end_date
         return earlier_bound <= d <= later_bound
 
-
-ApproxDate.FUTURE = ApproxDate(_max_date, _max_date)
-ApproxDate.PAST = ApproxDate(_min_date, _min_date)

--- a/approx_dates/tests/test_creation.py
+++ b/approx_dates/tests/test_creation.py
@@ -61,10 +61,12 @@ class TestCreation(TestCase):
         assert d.latest_date == date(1, 1, 1)
         assert text_type(d) == 'past'
 
-    def test_future_past_immutable(self):
-        p = ApproxDate.PAST
-        p.earliest_date = date(1,1,5)
-        assert p != ApproxDate.PAST
+    def test_future_immutable(self):
         p = ApproxDate.FUTURE
         p.earliest_date = date(8888, 12, 31)
+        assert p != ApproxDate.PAST
+
+    def test_past_immutable(self):
+        p = ApproxDate.PAST
+        p.earliest_date = date(1,1,5)
         assert p != ApproxDate.PAST

--- a/approx_dates/tests/test_creation.py
+++ b/approx_dates/tests/test_creation.py
@@ -60,3 +60,11 @@ class TestCreation(TestCase):
         assert d.earliest_date == date(1, 1, 1)
         assert d.latest_date == date(1, 1, 1)
         assert text_type(d) == 'past'
+
+    def test_future_past_immutable(self):
+        p = ApproxDate.PAST
+        p.earliest_date = date(1,1,5)
+        assert p != ApproxDate.PAST
+        p = ApproxDate.FUTURE
+        p.earliest_date = date(8888, 12, 31)
+        assert p != ApproxDate.PAST


### PR DESCRIPTION
Calling ApproxDate.PAST and .FUTURE will now return a new instance
rather than a shared one.

Prevents modifying the result of .PAST ruining all future comparisons.