### PR TITLE
Allow comparison of ApproxDate to None without error.

### DIFF
--- a/approx_dates/models.py
+++ b/approx_dates/models.py
@@ -74,8 +74,11 @@ class ApproxDate(object):
         if isinstance(other, date):
             return self.earliest_date == self.latest_date and \
                self.earliest_date == other
-        return self.earliest_date == other.earliest_date and \
-            self.latest_date == other.latest_date
+        if hasattr(other,"earliest_date") and hasattr(other,"latest_date"):
+            return self.earliest_date == other.earliest_date and \
+                self.latest_date == other.latest_date
+        else:
+            return False
 
     def __ne__(self, other):
         return not (self == other)

--- a/approx_dates/tests/test_equality.py
+++ b/approx_dates/tests/test_equality.py
@@ -59,3 +59,10 @@ class TestApproxDateEquality(TestCase):
         approx_date = ApproxDate.from_iso8601('1999')
         datetime_date = date(1964, 6, 26)
         assert not (approx_date == datetime_date)
+        
+    # Comparisons to other objects should be false, not fail 
+    def test_past_is_not_non_date(self):
+        approx_date = ApproxDate.PAST
+        assert not (approx_date == None)
+        assert not (approx_date == "past")
+        assert not (approx_date == 15)


### PR DESCRIPTION
Comparison tests to non-date-objects (like None) will return False,
not fail.